### PR TITLE
Add Random as a dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "1.0.1"
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Crayons = "4.0.2"

--- a/src/Bobby.jl
+++ b/src/Bobby.jl
@@ -1,8 +1,9 @@
 module Bobby
-    
+
     export Bitboard
     using Printf
     using Crayons
+    using Random
 
     include("structs.jl")
     include("constants.jl")
@@ -17,4 +18,3 @@ module Bobby
     include("move.jl")
     include("perft.jl")
 end
-

--- a/test/test_magic.jl
+++ b/test/test_magic.jl
@@ -24,8 +24,6 @@
     [@test Bb.BISHOP_BITS[p2u[s]] == 7 for s in ["c3", "f5", "e3"]]
     [@test Bb.BISHOP_BITS[p2u[s]] == 9 for s in ["d4", "e5"]]
 
-    @test Base.summarysize(Bb.DIAGO_OCCS) == 49080
-    @test Base.summarysize(Bb.ORTHO_OCCS) == 826296
     @test (Bb.MASK_RANKS[1] & ~p2u["h1"] ⊻ Bb.MASK_FILES[1] & ~p2u["a8"]) in Bb.ORTHO_OCCS[p2u["a1"]]
 
     @test Bb.randomMagic() != Bb.randomMagic()


### PR DESCRIPTION
In Julia 1.11 some work has been done to move standard libraries out of the "sysimage" and also make them upgradable (so they would no longer be strongly tied to the Julia version). The Random stdlib is a bit special in the sense that it commits "type piracy" by overloading the `Base.rand` function for types that it doesn't own. An example of that is `rand()` which is defined in `Random`.
While code will still be able to call `rand()` etc in 1.11 without loading `Random` there are some performance implications that makes it so it is better to load `Random` up front.

I also removed a test which is unreliable between Julia versions and feels pretty pointless to actually test for. 