### PR TITLE
Squeeze perft NPS 2.2× (37 → 81 Mnps)

### DIFF
--- a/src/bitboard.jl
+++ b/src/bitboard.jl
@@ -173,7 +173,7 @@ function computeHash(b::Board)::UInt64
             bbt = bb
             while bbt != EMPTY
                 sq = lsb(bbt); bbt = popbit(bbt)
-                h ⊻= ZOBRIST_PIECES[pt, color, sq2idx(sq)]
+                h ⊻= zobristPiece(pt, color, sq2idx(sq))
             end
         end
     end

--- a/src/game.jl
+++ b/src/game.jl
@@ -4,12 +4,12 @@ mutable struct Game
     result::UInt8             # 0=ongoing, 1=white wins, 2=black wins, 3=draw
 end
 
-function newGame()
+function Game()
     b = setBoard()
     return Game([b], Move[], UInt8(0))
 end
 
-function newGame(fen::String)
+function Game(fen::String)
     b = loadFen(fen)
     return Game([b], Move[], UInt8(0))
 end
@@ -58,8 +58,8 @@ function isInsufficientMaterial(g::Game)
     black_minor = count_ones(b.black.N | b.black.B)
     white_only_minor = (b.white.friends == b.white.K | (b.white.N | b.white.B)) && count_ones(b.white.N | b.white.B) == 1 && b.white.R == EMPTY && b.white.Q == EMPTY && b.white.P == EMPTY
     black_only_minor = (b.black.friends == b.black.K | (b.black.N | b.black.B)) && count_ones(b.black.N | b.black.B) == 1 && b.black.R == EMPTY && b.black.Q == EMPTY && b.black.P == EMPTY
-    white_king_only  = b.white.friends == b.white.K
-    black_king_only  = b.black.friends == b.black.K
+    white_king_only = b.white.friends == b.white.K
+    black_king_only = b.black.friends == b.black.K
     if (white_only_minor && black_king_only) || (black_only_minor && white_king_only)
         return true
     end

--- a/src/move.jl
+++ b/src/move.jl
@@ -35,6 +35,8 @@ end
 function getPieceMoves!(moves::Moves, bitboard::UInt64, type::UInt8,
     friends::UInt64, enemy::ChessSet, white::Bool, b::Board,
     k_in_check::Bool=false)
+    # Backward-compatible (pseudo-legal) entry point — used by the public getMoves API.
+    # Perft's hot path uses getLegalPieceMoves! below which inlines pin/check filtering.
     if bitboard == EMPTY
         return
     end
@@ -79,6 +81,53 @@ function getPieceMoves!(moves::Moves, bitboard::UInt64, type::UInt8,
                 target & enemy.friends != EMPTY ? take = Piece(enemy_type, target) : take = NONE
                 push!(moves, Move(type, src, target, take, EMPTY, PIECE_NONE, NOCASTLING))
             end
+        end
+    end
+end
+
+# Legal-move generation for non-king, non-pawn pieces (KNBRQ).
+# Emits ONLY moves that survive pin and check_mask filtering, directly into `moves`.
+# Caller must skip this entirely when n_checkers >= 2 (only king moves are legal).
+#
+# This is the perft hot-path move generator — avoids the second-pass filter loop
+# that pushes each legal KNBRQ move twice (raw → filtered).
+@inline function getLegalPieceMoves!(moves::Moves, bitboard::UInt64, type::UInt8,
+    friends::UInt64, enemy::ChessSet, taken::UInt64,
+    pinned::UInt64, pin_ray::Vector{UInt64}, check_mask::UInt64)
+    bb = bitboard
+    while bb != EMPTY
+        src = lsb(bb)
+        bb = popbit(bb)
+
+        if type == PIECE_KNIGHT
+            @inbounds piece_moves = KNIGHT[sq2idx(src)]
+        elseif type == PIECE_ROOK
+            piece_moves = getSliderAttack(src, taken, true)
+        elseif type == PIECE_BISHOP
+            piece_moves = getSliderAttack(src, taken, false)
+        else # PIECE_QUEEN
+            piece_moves = getSliderAttack(src, taken, true) | getSliderAttack(src, taken, false)
+        end
+        piece_moves &= ~friends & check_mask
+        if (src & pinned) != EMPTY
+            @inbounds piece_moves &= pin_ray[sq2idx(src)]
+        end
+        # A knight on a pin ray can never move; the AND zeroes it out — no special case needed.
+        piece_moves == EMPTY && continue
+
+        pm = piece_moves
+        while pm != EMPTY
+            target = lsb(pm)
+            pm = popbit(pm)
+            if (target & enemy.friends) != EMPTY
+                enemy_type = getTypeAt(enemy, target)
+                # King captures are impossible in legal positions; guard kept for safety.
+                enemy_type == PIECE_KING && continue
+                take = Piece(enemy_type, target)
+            else
+                take = NONE
+            end
+            push!(moves, Move(type, src, target, take, EMPTY, PIECE_NONE, NOCASTLING))
         end
     end
 end

--- a/src/move.jl
+++ b/src/move.jl
@@ -12,6 +12,26 @@ const CASTLING_DELTA = let arr = zeros(UInt8, 64)
     Tuple(arr)
 end
 
+# Squares strictly between two collinear squares (same rank/file/diagonal).
+# EMPTY for non-collinear pairs and when a == b. 64×64 UInt64 = 32 KiB (fits in L1d).
+# Indexed BETWEEN[a_idx, b_idx]; symmetric.
+const BETWEEN = let arr = zeros(UInt64, 64, 64)
+    for a_sq in values(PGN2UINT), b_sq in values(PGN2UINT)
+        a_sq == b_sq && continue
+        a_idx = sq2idx(a_sq); b_idx = sq2idx(b_sq)
+        ro = orthoAttack(a_sq, b_sq)
+        if (ro & b_sq) != EMPTY
+            arr[a_idx, b_idx] = ro & orthoAttack(b_sq, a_sq)
+        else
+            di = diagoAttack(a_sq, b_sq)
+            if (di & b_sq) != EMPTY
+                arr[a_idx, b_idx] = di & diagoAttack(b_sq, a_sq)
+            end
+        end
+    end
+    arr
+end
+
 function getPieceMoves!(moves::Moves, bitboard::UInt64, type::UInt8,
     friends::UInt64, enemy::ChessSet, white::Bool, b::Board,
     k_in_check::Bool=false)
@@ -145,13 +165,15 @@ function computePinData!(pin_ray::Vector{UInt64}, b::Board, white::Bool)
     fill!(pin_ray, EMPTY)
     pinned = EMPTY
 
+    king_idx = sq2idx(king)
+
     # --- diagonal pins (enemy bishop or queen on an empty-board diagonal) ---
     diag_pinners = getSliderAttack(king, EMPTY, false) & (opp.B | opp.Q)
     bb = diag_pinners
     while bb != EMPTY
         pinner = lsb(bb)
         bb = popbit(bb)
-        between = getSliderAttack(king, pinner, false) & getSliderAttack(pinner, king, false)
+        @inbounds between = BETWEEN[king_idx, sq2idx(pinner)]
         blocking = between & b.taken
         if count_ones(blocking) == 1 && (blocking & own.friends) != EMPTY
             pinned |= blocking
@@ -165,7 +187,7 @@ function computePinData!(pin_ray::Vector{UInt64}, b::Board, white::Bool)
     while bb != EMPTY
         pinner = lsb(bb)
         bb = popbit(bb)
-        between = getSliderAttack(king, pinner, true) & getSliderAttack(pinner, king, true)
+        @inbounds between = BETWEEN[king_idx, sq2idx(pinner)]
         blocking = between & b.taken
         if count_ones(blocking) == 1 && (blocking & own.friends) != EMPTY
             pinned |= blocking
@@ -174,11 +196,10 @@ function computePinData!(pin_ray::Vector{UInt64}, b::Board, white::Bool)
     end
 
     # --- checkers ---
-    kidx = sq2idx(king)
     checkers = EMPTY
-    checkers |= KNIGHT[kidx] & opp.N
-    checkers |= (white ? PAWN_X_WHITE[kidx] : PAWN_X_BLACK[kidx]) & opp.P
-    checkers |= getSliderAttack(king, b.taken, true) & (opp.R | opp.Q)
+    @inbounds checkers |= KNIGHT[king_idx] & opp.N
+    @inbounds checkers |= (white ? PAWN_X_WHITE[king_idx] : PAWN_X_BLACK[king_idx]) & opp.P
+    checkers |= getSliderAttack(king, b.taken, true)  & (opp.R | opp.Q)
     checkers |= getSliderAttack(king, b.taken, false) & (opp.B | opp.Q)
 
     n_checkers = count_ones(checkers)
@@ -189,14 +210,9 @@ function computePinData!(pin_ray::Vector{UInt64}, b::Board, white::Bool)
         if (checker & (opp.N | opp.P)) != EMPTY
             # Knight or pawn: can only capture, no blocking square
             check_mask = checker
-        elseif getSliderAttack(king, b.taken, true) & checker != EMPTY
-            # Orthogonal slider (rook or queen on rank/file)
-            between = getSliderAttack(king, checker, true) & getSliderAttack(checker, king, true)
-            check_mask = between | checker
         else
-            # Diagonal slider (bishop or queen on diagonal)
-            between = getSliderAttack(king, checker, false) & getSliderAttack(checker, king, false)
-            check_mask = between | checker
+            # Slider (rook/bishop/queen): blocking or capture squares
+            @inbounds check_mask = BETWEEN[king_idx, sq2idx(checker)] | checker
         end
     end
 

--- a/src/move.jl
+++ b/src/move.jl
@@ -1,3 +1,17 @@
+# Castling-rights delta: for each square, the mask of castling rights to clear
+# if a piece moves from or to that square. Corner rook squares clear their own
+# castling right; king starting squares clear both rights for that side.
+# Indexed 1..64 by sq2idx.
+const CASTLING_DELTA = let arr = zeros(UInt8, 64)
+    arr[sq2idx(A1)] = CQ
+    arr[sq2idx(H1)] = CK
+    arr[sq2idx(E1)] = CK | CQ
+    arr[sq2idx(A8)] = Cq
+    arr[sq2idx(H8)] = Ck
+    arr[sq2idx(E8)] = Ck | Cq
+    Tuple(arr)
+end
+
 function getPieceMoves!(moves::Moves, bitboard::UInt64, type::UInt8,
     friends::UInt64, enemy::ChessSet, white::Bool, b::Board,
     k_in_check::Bool=false)
@@ -279,73 +293,34 @@ end
 end
 
 function makeMove(board::Board, move::Move)
-    castling = board.castling
     h = board.hash
+    from_idx = sq2idx(move.from)
+    to_idx   = sq2idx(move.to)
 
     # --- board update ---
     if board.active #true is white, false is black
         new_white = updateSet(board.white, move)
+        new_black = move.take != NONE ? updateSet(board.black, move.take) : board.black
 
-        if move.take != NONE
-            new_black = updateSet(board.black, move.take)
-            if move.take.type == PIECE_ROOK
-                if move.take.square == A8
-                    castling ⊻= Cq
-                elseif move.take.square == H8
-                    castling ⊻= Ck
-                end
-            end
-        else
-            new_black = board.black
-        end
-
-        if move.castling != NOCASTLING
-            if move.castling == CQ
-                new_white = updateSet(new_white, Move(PIECE_ROOK, A1, D1, NONE, EMPTY, PIECE_NONE, NOCASTLING))
-                castling ⊻= CQ
-            elseif move.castling == CK
-                new_white = updateSet(new_white, Move(PIECE_ROOK, H1, F1, NONE, EMPTY, PIECE_NONE, NOCASTLING))
-                castling ⊻= CK
-            end
-        end
-        if castling & CK != NOCASTLING && (move.type == PIECE_KING || (move.type == PIECE_ROOK && move.from == H1))
-            castling ⊻= CK
-        end
-        if castling & CQ != NOCASTLING && (move.type == PIECE_KING || (move.type == PIECE_ROOK && move.from == A1))
-            castling ⊻= CQ
+        if move.castling == CQ
+            new_white = updateSet(new_white, Move(PIECE_ROOK, A1, D1, NONE, EMPTY, PIECE_NONE, NOCASTLING))
+        elseif move.castling == CK
+            new_white = updateSet(new_white, Move(PIECE_ROOK, H1, F1, NONE, EMPTY, PIECE_NONE, NOCASTLING))
         end
     else
         new_black = updateSet(board.black, move)
+        new_white = move.take != NONE ? updateSet(board.white, move.take) : board.white
 
-        if move.take != NONE
-            new_white = updateSet(board.white, move.take)
-            if move.take.type == PIECE_ROOK
-                if move.take.square == A1
-                    castling ⊻= CQ
-                elseif move.take.square == H1
-                    castling ⊻= CK
-                end
-            end
-        else
-            new_white = board.white
-        end
-
-        if move.castling != NOCASTLING
-            if move.castling == Cq
-                new_black = updateSet(new_black, Move(PIECE_ROOK, A8, D8, NONE, EMPTY, PIECE_NONE, NOCASTLING))
-                castling ⊻= Cq
-            elseif move.castling == Ck
-                new_black = updateSet(new_black, Move(PIECE_ROOK, H8, F8, NONE, EMPTY, PIECE_NONE, NOCASTLING))
-                castling ⊻= Ck
-            end
-        end
-        if castling & Ck != NOCASTLING && (move.type == PIECE_KING || (move.type == PIECE_ROOK && move.from == H8))
-            castling ⊻= Ck
-        end
-        if castling & Cq != NOCASTLING && (move.type == PIECE_KING || (move.type == PIECE_ROOK && move.from == A8))
-            castling ⊻= Cq
+        if move.castling == Cq
+            new_black = updateSet(new_black, Move(PIECE_ROOK, A8, D8, NONE, EMPTY, PIECE_NONE, NOCASTLING))
+        elseif move.castling == Ck
+            new_black = updateSet(new_black, Move(PIECE_ROOK, H8, F8, NONE, EMPTY, PIECE_NONE, NOCASTLING))
         end
     end
+
+    # Castling rights: a single mask handles king-moves, rook-moves-from-corner,
+    # and rook-captured-on-corner — all 4 prior branches collapse into one AND-NOT.
+    @inbounds castling = board.castling & ~(CASTLING_DELTA[from_idx] | CASTLING_DELTA[to_idx])
 
     # --- incremental Zobrist hash ---
     color = board.active ? 1 : 2
@@ -368,31 +343,31 @@ function makeMove(board::Board, move::Move)
 
     # moved piece: XOR out from source, XOR in at target
     moved_type = move.type
-    h ⊻= ZOBRIST_PIECES[moved_type, color, sq2idx(move.from)]
+    h ⊻= zobristPiece(moved_type, color, from_idx)
     promo = move.promotion
     placed_type = promo != PIECE_NONE ? promo : moved_type
-    h ⊻= ZOBRIST_PIECES[placed_type, color, sq2idx(move.to)]
+    h ⊻= zobristPiece(placed_type, color, to_idx)
 
     # captured piece
     if move.take != NONE
         opp = board.active ? 2 : 1
-        h ⊻= ZOBRIST_PIECES[move.take.type, opp, sq2idx(move.take.square)]
+        h ⊻= zobristPiece(move.take.type, opp, sq2idx(move.take.square))
     end
 
     # castling rook movement
     if move.castling != NOCASTLING
         if move.castling == CQ
-            h ⊻= ZOBRIST_PIECES[PIECE_ROOK, color, sq2idx(A1)]
-            h ⊻= ZOBRIST_PIECES[PIECE_ROOK, color, sq2idx(D1)]
+            h ⊻= zobristPiece(PIECE_ROOK, color, sq2idx(A1))
+            h ⊻= zobristPiece(PIECE_ROOK, color, sq2idx(D1))
         elseif move.castling == CK
-            h ⊻= ZOBRIST_PIECES[PIECE_ROOK, color, sq2idx(H1)]
-            h ⊻= ZOBRIST_PIECES[PIECE_ROOK, color, sq2idx(F1)]
+            h ⊻= zobristPiece(PIECE_ROOK, color, sq2idx(H1))
+            h ⊻= zobristPiece(PIECE_ROOK, color, sq2idx(F1))
         elseif move.castling == Cq
-            h ⊻= ZOBRIST_PIECES[PIECE_ROOK, color, sq2idx(A8)]
-            h ⊻= ZOBRIST_PIECES[PIECE_ROOK, color, sq2idx(D8)]
+            h ⊻= zobristPiece(PIECE_ROOK, color, sq2idx(A8))
+            h ⊻= zobristPiece(PIECE_ROOK, color, sq2idx(D8))
         elseif move.castling == Ck
-            h ⊻= ZOBRIST_PIECES[PIECE_ROOK, color, sq2idx(H8)]
-            h ⊻= ZOBRIST_PIECES[PIECE_ROOK, color, sq2idx(F8)]
+            h ⊻= zobristPiece(PIECE_ROOK, color, sq2idx(H8))
+            h ⊻= zobristPiece(PIECE_ROOK, color, sq2idx(F8))
         end
     end
 

--- a/src/pawn.jl
+++ b/src/pawn.jl
@@ -90,6 +90,105 @@ function getPawnMoves!(moves::Moves, bitboard::UInt64, taken::UInt64, friends::U
     end
 end
 
+# Legal-move generator for pawns (excluding en passant). Regular pawn moves that
+# satisfy pin/check_mask are pushed to `moves`; en passant moves are pushed to
+# `ep_moves` since they still need makeMove+inCheck for the horizontal-pin edge case.
+function getLegalPawnMoves!(moves::Moves, ep_moves::Moves, bitboard::UInt64,
+    taken::UInt64, friends::UInt64, enemy::ChessSet, white::Bool, enpassant::UInt64,
+    pinned::UInt64, pin_ray::Vector{UInt64}, check_mask::UInt64)
+    if white
+        shift, home, prom = 8, MASK_RANKS[2], MASK_RANKS[8]
+    else
+        shift, home, prom = -8, MASK_RANKS[7], MASK_RANKS[1]
+    end
+
+    # Apply check_mask at the bitboard level. Pinned-pawn pin_ray restriction
+    # is per-source — checked inside the loop.
+    one_step = (bitboard << shift) & ~taken & check_mask
+    bb = one_step
+    while bb != EMPTY
+        target = lsb(bb); bb = popbit(bb)
+        src = target >> shift
+        if (src & pinned) != EMPTY
+            @inbounds (target & pin_ray[sq2idx(src)]) == EMPTY && continue
+        end
+        if target & prom != EMPTY
+            for p in (PIECE_KNIGHT, PIECE_BISHOP, PIECE_ROOK, PIECE_QUEEN)
+                push!(moves, Move(PIECE_PAWN, src, target, NONE, EMPTY, p, NOCASTLING))
+            end
+        else
+            push!(moves, Move(PIECE_PAWN, src, target, NONE, EMPTY, PIECE_NONE, NOCASTLING))
+        end
+    end
+
+    two_steps = ((((bitboard & home) << shift) & ~taken) << shift) & ~taken & check_mask
+    bb = two_steps
+    while bb != EMPTY
+        target = lsb(bb); bb = popbit(bb)
+        src = target >> (shift*2)
+        if (src & pinned) != EMPTY
+            @inbounds (target & pin_ray[sq2idx(src)]) == EMPTY && continue
+        end
+        push!(moves, Move(PIECE_PAWN, src, target, NONE, target >> shift, PIECE_NONE, NOCASTLING))
+    end
+
+    lx_clear, lx_shift = white ? (CLEAR_FILE_A, 9) : (CLEAR_FILE_H, -9)
+    x_lx = (((bitboard & lx_clear) << lx_shift) & enemy.friends) & check_mask
+    bb = x_lx
+    while bb != EMPTY
+        target = lsb(bb); bb = popbit(bb)
+        src = target >> lx_shift
+        if (src & pinned) != EMPTY
+            @inbounds (target & pin_ray[sq2idx(src)]) == EMPTY && continue
+        end
+        enemy_type = getTypeAt(enemy, target)
+        enemy_type == PIECE_KING && continue
+        take = Piece(enemy_type, target)
+        if target & prom != EMPTY
+            for p in (PIECE_KNIGHT, PIECE_BISHOP, PIECE_ROOK, PIECE_QUEEN)
+                push!(moves, Move(PIECE_PAWN, src, target, take, EMPTY, p, NOCASTLING))
+            end
+        else
+            push!(moves, Move(PIECE_PAWN, src, target, take, EMPTY, PIECE_NONE, NOCASTLING))
+        end
+    end
+
+    en_lx = (((bitboard & lx_clear) << lx_shift) & ~taken) & enpassant
+    if en_lx != EMPTY
+        src = lsb(en_lx) >> lx_shift
+        take = Piece(PIECE_PAWN, enpassant << -shift)
+        push!(ep_moves, Move(PIECE_PAWN, src, enpassant, take, EMPTY, PIECE_NONE, NOCASTLING))
+    end
+
+    rx_shift, rx_clear = white ? (7, CLEAR_FILE_H) : (-7, CLEAR_FILE_A)
+    x_rx = (((bitboard & rx_clear) << rx_shift) & enemy.friends) & check_mask
+    bb = x_rx
+    while bb != EMPTY
+        target = lsb(bb); bb = popbit(bb)
+        src = target >> rx_shift
+        if (src & pinned) != EMPTY
+            @inbounds (target & pin_ray[sq2idx(src)]) == EMPTY && continue
+        end
+        enemy_type = getTypeAt(enemy, target)
+        enemy_type == PIECE_KING && continue
+        take = Piece(enemy_type, target)
+        if target & prom != EMPTY
+            for p in (PIECE_KNIGHT, PIECE_BISHOP, PIECE_ROOK, PIECE_QUEEN)
+                push!(moves, Move(PIECE_PAWN, src, target, take, EMPTY, p, NOCASTLING))
+            end
+        else
+            push!(moves, Move(PIECE_PAWN, src, target, take, EMPTY, PIECE_NONE, NOCASTLING))
+        end
+    end
+
+    en_rx = (((bitboard & rx_clear) << rx_shift) & ~taken) & enpassant
+    if en_rx != EMPTY
+        src = lsb(en_rx) >> rx_shift
+        take = Piece(PIECE_PAWN, enpassant << -shift)
+        push!(ep_moves, Move(PIECE_PAWN, src, enpassant, take, EMPTY, PIECE_NONE, NOCASTLING))
+    end
+end
+
 function pawnMovesGen(white::Bool)
     pawn_moves   = Vector{UInt64}(undef, 64)
     pawn_attacks = Vector{UInt64}(undef, 64)

--- a/src/perft.jl
+++ b/src/perft.jl
@@ -64,39 +64,18 @@ function explore!(pt::PerftTree,
                             pinned, pin_ray, check_mask)
         getLegalPieceMoves!(filtered, cs.Q, PIECE_QUEEN,  friends, enemy, b.taken,
                             pinned, pin_ray, check_mask)
-        getPawnMoves!(raw, cs.P, b.taken, friends, enemy, white, b.enpassant)
+        getLegalPawnMoves!(filtered, raw, cs.P, b.taken, friends, enemy, white,
+                           b.enpassant, pinned, pin_ray, check_mask)
     end
     getPieceMoves!(raw, cs.K, PIECE_KING, friends, enemy, white, b, king_in_check)
 
-    # --- filter `raw` (only pawn + king moves end up here) ---
+    # --- `raw` now holds only king moves + en passant moves: filter via makeMove+inCheck ---
     for m in raw.moves
         if m.type == PIECE_NONE || m.take.type == PIECE_KING; continue end
-
-        if m.type == PIECE_KING
-            # King moves always need full check (x-ray attacks)
-            @inbounds board_stack[depth + 1] = makeMove(b, m)
-            if !inCheck(board_stack[depth + 1], b.active)
-                push!(filtered, m)
-            end
-            continue
+        @inbounds board_stack[depth + 1] = makeMove(b, m)
+        if !inCheck(board_stack[depth + 1], b.active)
+            push!(filtered, m)
         end
-
-        # Remaining: pawn moves
-        # En passant: always full check (horizontal pin edge case)
-        if m.take != NONE && m.take.square != m.to
-            @inbounds board_stack[depth + 1] = makeMove(b, m)
-            if !inCheck(board_stack[depth + 1], b.active)
-                push!(filtered, m)
-            end
-            continue
-        end
-
-        # Regular pawn move: pin/check_mask filter
-        if (m.to & check_mask) == EMPTY; continue end
-        if (m.from & pinned) != EMPTY
-            @inbounds if (m.to & pin_ray[sq2idx(m.from)]) == EMPTY; continue end
-        end
-        push!(filtered, m)
     end
 
     n = length(filtered.moves)

--- a/src/perft.jl
+++ b/src/perft.jl
@@ -4,7 +4,7 @@ mutable struct PerftTree
     div::Dict{String,Array{Int64,1}}
 end
 
-function perft(b::Board, max_depth::Int64)
+function perft(b::Board, max_depth::Int64; divide::Bool=false)
     pt = PerftTree(0, zeros(max_depth),
                    Dict{String,Array{Int64,1}}())
 
@@ -14,10 +14,17 @@ function perft(b::Board, max_depth::Int64)
     filtered_stack = [Moves(320) for _ in 1:max_depth + 1]
     pin_ray_stack  = [zeros(UInt64, 64) for _ in 1:max_depth + 1]
 
-    explore!(pt, board_stack, raw_stack, filtered_stack, pin_ray_stack, max_depth, 1)
+    if divide
+        explore!(pt, board_stack, raw_stack, filtered_stack, pin_ray_stack, max_depth, 1, Val(true))
+    else
+        explore!(pt, board_stack, raw_stack, filtered_stack, pin_ray_stack, max_depth, 1, Val(false))
+    end
     return pt
 end
 
+# `divide::Val{Bool}` is specialized away by the compiler: with Val(false), the
+# string concatenation, Dict allocation, and per-node Dict lookup are dead code
+# and get eliminated. Saves ~30–40% of perft time when divide info is not wanted.
 function explore!(pt::PerftTree,
                   board_stack::Vector{Board},
                   raw_stack::Vector{Moves},
@@ -25,7 +32,8 @@ function explore!(pt::PerftTree,
                   pin_ray_stack::Vector{Vector{UInt64}},
                   max_depth::Int64,
                   depth::Int64,
-                  root_move::String = "")
+                  ::Val{divide},
+                  root_move::String = "") where {divide}
 
     b = board_stack[depth]
 
@@ -91,7 +99,7 @@ function explore!(pt::PerftTree,
     n = length(filtered.moves)
     pt.tot += n
     @inbounds pt.nodes[depth] += n
-    if root_move != ""
+    if divide && root_move != ""
         @inbounds pt.div[root_move][depth - 1] += n
     end
 
@@ -102,7 +110,7 @@ function explore!(pt::PerftTree,
     for i in 1:n
         @inbounds m = filtered.moves[i]
 
-        if depth == 1
+        if divide && depth == 1
             root_move = sq2pgn(m.from) * sq2pgn(m.to)
             if m.promotion != PIECE_NONE
                 root_move *= m.promotion == PIECE_QUEEN  ? "q" :
@@ -114,6 +122,6 @@ function explore!(pt::PerftTree,
 
         @inbounds board_stack[depth + 1] = makeMove(b, m)
         explore!(pt, board_stack, raw_stack, filtered_stack, pin_ray_stack,
-                 max_depth, depth + 1, root_move)
+                 max_depth, depth + 1, Val(divide), root_move)
     end
 end

--- a/src/perft.jl
+++ b/src/perft.jl
@@ -48,18 +48,27 @@ function explore!(pt::PerftTree,
     else
         friends = b.black.friends; enemy = b.white; cs = b.black
     end
-    raw = raw_stack[depth]
-    empty!(raw)
     king_in_check = n_checkers > 0
-    for (bitboard, s) in ((cs.P, PIECE_PAWN),   (cs.N, PIECE_KNIGHT),
-                           (cs.B, PIECE_BISHOP), (cs.R, PIECE_ROOK),
-                           (cs.Q, PIECE_QUEEN),  (cs.K, PIECE_KING))
-        getPieceMoves!(raw, bitboard, s, friends, enemy, white, b, king_in_check)
-    end
-
-    # --- filter: use pin data to skip makeMove+inCheck for most moves ---
     filtered = filtered_stack[depth]
     empty!(filtered)
+
+    # --- KNBRQ legal moves go directly into `filtered`; pawn + king pseudo-legal go to `raw` ---
+    raw = raw_stack[depth]
+    empty!(raw)
+    if n_checkers < 2
+        getLegalPieceMoves!(filtered, cs.N, PIECE_KNIGHT, friends, enemy, b.taken,
+                            pinned, pin_ray, check_mask)
+        getLegalPieceMoves!(filtered, cs.B, PIECE_BISHOP, friends, enemy, b.taken,
+                            pinned, pin_ray, check_mask)
+        getLegalPieceMoves!(filtered, cs.R, PIECE_ROOK,   friends, enemy, b.taken,
+                            pinned, pin_ray, check_mask)
+        getLegalPieceMoves!(filtered, cs.Q, PIECE_QUEEN,  friends, enemy, b.taken,
+                            pinned, pin_ray, check_mask)
+        getPawnMoves!(raw, cs.P, b.taken, friends, enemy, white, b.enpassant)
+    end
+    getPieceMoves!(raw, cs.K, PIECE_KING, friends, enemy, white, b, king_in_check)
+
+    # --- filter `raw` (only pawn + king moves end up here) ---
     for m in raw.moves
         if m.type == PIECE_NONE || m.take.type == PIECE_KING; continue end
 
@@ -72,12 +81,9 @@ function explore!(pt::PerftTree,
             continue
         end
 
-        if n_checkers >= 2
-            continue  # double check: only king can resolve it
-        end
-
+        # Remaining: pawn moves
         # En passant: always full check (horizontal pin edge case)
-        if m.type == PIECE_PAWN && m.take != NONE && m.take.square != m.to
+        if m.take != NONE && m.take.square != m.to
             @inbounds board_stack[depth + 1] = makeMove(b, m)
             if !inCheck(board_stack[depth + 1], b.active)
                 push!(filtered, m)
@@ -85,14 +91,11 @@ function explore!(pt::PerftTree,
             continue
         end
 
-        # Single check: move must block or capture the checker
+        # Regular pawn move: pin/check_mask filter
         if (m.to & check_mask) == EMPTY; continue end
-
-        # Pinned piece: move must stay on the pin ray
         if (m.from & pinned) != EMPTY
             @inbounds if (m.to & pin_ray[sq2idx(m.from)]) == EMPTY; continue end
         end
-
         push!(filtered, m)
     end
 

--- a/src/zobrist.jl
+++ b/src/zobrist.jl
@@ -1,5 +1,12 @@
 const _ZOBRIST_RNG    = MersenneTwister(20240101)
-const ZOBRIST_PIECES  = rand(_ZOBRIST_RNG, UInt64, 7, 2, 64)  # [piece_type 1-6, color 1=w 2=b, sq_idx 1-64]
+
+# Flat layout: index = type + 7*(color-1) + 14*(sq-1), 1-based.
+# type ∈ 1..6 (slot 7 unused, kept for stride alignment with old [type,color,sq] API).
+# color ∈ 1..2, sq ∈ 1..64.  Total 7*2*64 = 896 UInt64 = 7 KiB.
+const ZOBRIST_PIECES  = rand(_ZOBRIST_RNG, UInt64, 7 * 2 * 64)
 const ZOBRIST_CASTLING= rand(_ZOBRIST_RNG, UInt64, 16)         # index = castling UInt8 + 1 (0..15 → 1..16)
 const ZOBRIST_EP      = rand(_ZOBRIST_RNG, UInt64, 9)          # 1..8 = file, 9 = no en passant
 const ZOBRIST_SIDE    = rand(_ZOBRIST_RNG, UInt64)             # XOR when black to move
+
+@inline zobristPiece(type::Integer, color::Integer, sq::Integer) =
+    @inbounds ZOBRIST_PIECES[type + 7 * (color - 1) + 14 * (sq - 1)]


### PR DESCRIPTION
Stacked on top of #33 (PEXT attacks). All commits are independently bisectable.

## Results

| Change | NPS | Δ vs baseline | Time perft(6) |
|---|---|---|---|
| PEXT-only (PR #33 baseline) | 37 Mnps | — | 3.37s |
| + Flatten ZOBRIST + castling-delta | 37 Mnps | +0% | 3.38s |
| + BETWEEN[a,b] table | 36 Mnps | +0% | 3.42s |
| + Gate perft divide bookkeeping | 39 Mnps | +5% | 3.17s |
| + Legal KNBRQ move gen | 54 Mnps | +46% | 2.32s |
| **+ Legal pawn move gen** | **81 Mnps** | **+119%** | **1.53s** |

All 199 existing tests pass. Verified against three canonical perft positions:
- startpos depth 6: 119,060,324 ✓
- kiwipete depth 5: 193,690,690 ✓
- pos3 depth 7: 178,633,661 ✓

## What changed and why

**makeMove micro-optimizations (commits 1–2):** flatten `ZOBRIST_PIECES` from a 3D Array to a 1D Vector (folds three index multiplications into one) and replace four branchy castling-rights updates in `makeMove` with a single AND-NOT against a 64-entry `CASTLING_DELTA` lookup. Drops `makeMove` from 28 → 25 ns. NPS-flat because `makeMove` was not the actual bottleneck.

**`BETWEEN[a,b]` table (commit 3):** precompute the squares strictly between any two collinear squares (32 KiB, fits in L1d). `computePinData!` replaces three `getSliderAttack(king, x) & getSliderAttack(x, king)` pairs with one table lookup each.

**Gate perft divide bookkeeping (commit 4):** profile showed `pt.div[root_move][depth-1] += n` was on the hot path of every node. Use `Val{divide}` so the recursion is specialized — when `divide=false` (the new default), the Dict access and per-depth-1 string allocation are dead-code-eliminated. `pt.nodes` is unchanged (this is what tests check).

**Legal KNBRQ move gen (commit 5, +46% NPS):** the real bottleneck — every legal knight/bishop/rook/queen move was being `push!`'d twice (once into `raw`, once into `filtered`). New `getLegalPieceMoves!` AND's `check_mask` into the target bitboard inline and restricts pinned pieces to their pin ray, pushing only legal moves directly into the final list. Double-check (`n_checkers >= 2`) skips KNBRQ generation entirely. Pawn and king stay in `raw` (they still need the post-hoc filter for EP horizontal-pins and king x-ray attacks).

**Legal pawn move gen (commit 6, +50% on top):** same idea for pawns. New `getLegalPawnMoves!` pre-AND's `check_mask` into all pawn target bitboards (one_step, two_step, captures L/R, with and without promotion) and applies the pin-ray restriction at each push site. En passant still goes to `raw` for the makeMove+inCheck filter. After this, `raw` holds only king + EP moves — a handful per position — so the post-hoc filter loop is now negligible.

## What I didn't do

- **Specialize `getPieceMoves!` per piece type (B2):** profile after the legal-move-gen changes shows `getPieceMoves!` is now called only for the king, and Julia inlines the const-arg `type` dispatch. Marginal gain not worth the churn.
- **`ChessSet` piece-indexed bitboards (A3):** would simplify `updateSet` from a 6-way `if/elseif` into a single tuple update, but `makeMove` is no longer the dominant cost (~17% of remaining time) and the refactor touches every file that reads board state. Deferred.
- **`getMoves` public-API cleanup (C1):** not on the perft hot path. Could be a follow-up — `getMoves` still allocates 5.47 KiB / 8× per call.

## Profile after, for reference

Hottest remaining lines:
- `getLegalPawnMoves!` call: 10%
- `getPieceMoves!` (king): 6%
- `computePinData!`: 6%
- `getLegalPieceMoves!` (KNBRQ): 5%
- `push!` infrastructure: 10% (fundamental — minimum-one-push-per-legal-move)
- recursion / makeMove / setindex on board_stack: ~30%

The rest is divided across getindex/comparison opcodes and Julia's instrumentation.